### PR TITLE
ignore too small groups

### DIFF
--- a/R/geoms.R
+++ b/R/geoms.R
@@ -138,6 +138,7 @@ GeomRidgeline <- ggproto("GeomRidgeline", Geom,
 
   draw_group = function(self, data, panel_params, coord, na.rm = FALSE) {
     if (na.rm) data <- data[stats::complete.cases(data[c("x", "ymin", "ymax")]), ]
+    if (nrow(data) == 0) return(grid::nullGrob())
     data <- data[order(data$group, data$x), ]
 
     # remove all points that fall below the minimum height

--- a/R/stats.R
+++ b/R/stats.R
@@ -41,7 +41,8 @@ StatJoy <- ggproto("StatJoy", Stat,
     if (is.null(params$bandwidth)) {
       xdata <- na.omit(data.frame(x=data$x, group=data$group))
       xs <- split(xdata$x, xdata$group)
-      bws <- vapply(xs, bw.nrd0, numeric(1))
+      xs_mask <- vapply(xs, length, numeric(1)) > 1
+      bws <- vapply(xs[xs_mask], bw.nrd0, numeric(1))
       bw <- mean(bws, na.rm = TRUE)
       message("Picking joint bandwidth of ", signif(bw, 3))
 
@@ -60,6 +61,9 @@ StatJoy <- ggproto("StatJoy", Stat,
   },
 
   compute_group = function(data, scales, min, max, bandwidth = 1) {
+    # ignore too small groups
+    if(nrow(data) < 3) return(data.frame())
+
     d <- density(data$x, bw = bandwidth, from = min, to = max, na.rm = TRUE)
     data.frame(x = d$x, density = d$y)
   }


### PR DESCRIPTION
Hi! Thanks for this neat package.

I've encountered an error when I played with a data that has only one record:

``` r
library(ggjoy)
#> Loading required package: ggplot2
d <- rbind(
  data.frame(value = runif(100), category = "a"),
  data.frame(value = runif(1),   category = "b"),    # cannot calculate the bandwidth
  data.frame(value = runif(100), category = "c"),
  data.frame(value = runif(2),   category = "d"),
  data.frame(value = runif(100), category = "e")
)

ggplot(d, aes(value, category)) + geom_joy()
#> Error in FUN(X[[i]], ...): need at least 2 data points
```

On the other hand, `geom_violin()` ignores too small groups silently, like this:

```r
ggplot(d, aes(category, value)) + geom_violin()
```

![image](https://user-images.githubusercontent.com/1978793/28459629-2c7c0390-6e49-11e7-9fcb-73aa5b7d8cc5.png)

More precisely, the logic is here:

```r
  compute_group = function(data, scales, width = NULL, bw = "nrd0", adjust = 1,
                       kernel = "gaussian", trim = TRUE, na.rm = FALSE) {
     if (nrow(data) < 3) return(data.frame())
```
(https://github.com/tidyverse/ggplot2/blob/8778b48b37d8b7e41c0f4f213031fb47810e70aa/R/stat-ydensity.r#L63-L65)

This PR fixes the error above by doing the same as `geom_violin()`. Example is bellow.

```r
ggplot(d, aes(value, category)) + geom_joy()
```
![image](https://user-images.githubusercontent.com/1978793/28459422-5ff63a7a-6e48-11e7-8a9c-f2712e36667b.png)
